### PR TITLE
Revamp UI and add demo user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,40 @@
 # Lawyer Dashboard
 
-This project is a MERN (MongoDB, Express, React and Node.js) dashboard for managing legal cases and client interactions. The server uses Node.js with Express and MongoDB, while the client runs on React.
+A simple MERN stack demonstration for managing legal cases.
 
-Development is at an early stage and additional instructions will be added as the project grows.
+## Requirements
+- Node.js >=20
+- MongoDB instance (Docker compose is provided)
 
-## Getting Started on Windows
+## Setup
+1. Create a `.env` file inside the `api` folder using `.env.example` as a template:
+   ```ini
+   MONGO_URI=mongodb://localhost:27017/lawyer
+   JWT_SECRET=changeme
+   ```
+2. Install dependencies:
+   ```bash
+   npm install --prefix api
+   npm install --prefix web
+   ```
+3. Start MongoDB (using Docker):
+   ```bash
+   docker-compose up -d
+   ```
+4. Seed a demo account and start the API server:
+   ```bash
+   npm run seed --prefix api
+   npm run dev --prefix api
+   ```
+   The seeded credentials are:
+   - **Email:** `demo@example.com`
+   - **Password:** `password123`
+5. Start the React client:
+   ```bash
+   npm run dev --prefix web
+   ```
+   Visit `http://localhost:5173` in your browser.
 
-```bash
-docker-compose up -d
-npm install --prefix api
-npm install --prefix web
-npm run dev --prefix api
-npm run dev --prefix web
-```
+## Project Structure
+- `api/` – Express + MongoDB backend
+- `web/` – React frontend built with Vite and Tailwind CSS

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,3 +1,5 @@
 MONGO_URI=
 JWT_SECRET=
 PORT=3000
+SEED_EMAIL=demo@example.com
+SEED_PASSWORD=password123

--- a/api/models/Evidence.js
+++ b/api/models/Evidence.js
@@ -5,7 +5,8 @@ const evidenceSchema = new mongoose.Schema({
   filename: { type: String, required: true },
   originalname: { type: String },
   mimetype: { type: String },
-  path: { type: String }
+  path: { type: String },
+  size: { type: Number }
 }, { timestamps: true });
 
 export default mongoose.model('Evidence', evidenceSchema);

--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon server.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "seed": "node seed.js"
   },
   "engines": {
     "node": ">=20"

--- a/api/routes/evidence.routes.js
+++ b/api/routes/evidence.routes.js
@@ -20,7 +20,8 @@ router.post('/:caseId', upload.single('file'), async (req, res) => {
       filename: req.file.filename,
       originalname: req.file.originalname,
       mimetype: req.file.mimetype,
-      path: req.file.path
+      path: req.file.path,
+      size: req.file.size
     });
     res.json(ev);
   } catch (err) {

--- a/api/seed.js
+++ b/api/seed.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import bcrypt from 'bcryptjs';
+import User from './models/User.js';
+
+dotenv.config();
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI);
+  const email = process.env.SEED_EMAIL || 'demo@example.com';
+  const password = process.env.SEED_PASSWORD || 'password123';
+  const existing = await User.findOne({ email });
+  if (existing) {
+    console.log('User already exists');
+  } else {
+    const hashed = await bcrypt.hash(password, 10);
+    await User.create({ email, password: hashed });
+    console.log('Created user', email);
+  }
+  await mongoose.disconnect();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/src/pages/CaseDetail.jsx
+++ b/web/src/pages/CaseDetail.jsx
@@ -1,20 +1,22 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import api from '../api.js';
 
 export default function CaseDetail() {
   const { id } = useParams();
-  const [c, setCase] = useState(null);
+  const navigate = useNavigate();
+  const [caseData, setCaseData] = useState(null);
   const [file, setFile] = useState(null);
   const [evidence, setEvidence] = useState([]);
 
   useEffect(() => {
-    api.get(`/cases/${id}`).then(res => setCase(res.data));
+    api.get(`/cases/${id}`).then(res => setCaseData(res.data));
     api.get(`/evidence/${id}`).then(res => setEvidence(res.data));
   }, [id]);
 
   const upload = async e => {
     e.preventDefault();
+    if (!file) return;
     const fd = new FormData();
     fd.append('file', file);
     await api.post(`/evidence/${id}`, fd, {
@@ -22,23 +24,40 @@ export default function CaseDetail() {
     });
     const { data } = await api.get(`/evidence/${id}`);
     setEvidence(data);
+    setFile(null);
   };
 
-  if (!c) return null;
+  if (!caseData) return null;
 
   return (
-    <div className="p-4">
-      <h2 className="text-xl mb-2">{c.title}</h2>
-      <p>Client: {c.client}</p>
-      <form onSubmit={upload} className="my-4">
-        <input type="file" onChange={e => setFile(e.target.files[0])} />
-        <button className="bg-blue-500 text-white px-4 py-2 ml-2">Upload</button>
-      </form>
-      <ul>
-        {evidence.map(ev => (
-          <li key={ev._id}>{ev.originalname}</li>
-        ))}
-      </ul>
+    <div className="min-h-screen bg-gray-100 text-gray-900">
+      <nav className="bg-slate-800 text-white p-3 px-6 flex items-center gap-4">
+        <button onClick={() => navigate('/')} className="text-sm hover:underline">← Back to Dashboard</button>
+      </nav>
+
+      <main className="p-6 max-w-5xl mx-auto">
+        <h2 className="text-xl font-semibold mb-1">{caseData.title}</h2>
+        <p className="text-gray-500 mb-6">Client: {caseData.client}</p>
+
+        <form onSubmit={upload} className="flex items-center gap-3 mb-8">
+          <input
+            type="file"
+            required
+            onChange={e => setFile(e.target.files[0])}
+            className="flex-1 border border-gray-300 rounded py-2 px-3 bg-white"
+          />
+          <button type="submit" className="bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-5 rounded text-sm">Upload</button>
+        </form>
+
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {evidence.map(ev => (
+            <a key={ev._id} href={`http://localhost:3000/uploads/${ev.filename}`} className="border border-gray-200 rounded-lg p-4 bg-white hover:shadow filecard" target="_blank" rel="noopener noreferrer">
+              <p className="truncate mb-1">{ev.originalname}</p>
+              <p className="text-xs text-gray-500">{(((ev.size ?? 0) / 1024).toFixed(1))} KB</p>
+            </a>
+          ))}
+        </section>
+      </main>
     </div>
   );
 }

--- a/web/src/pages/CaseForm.jsx
+++ b/web/src/pages/CaseForm.jsx
@@ -14,20 +14,31 @@ export default function CaseForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="p-4 max-w-sm mx-auto">
-      <input
-        className="border p-2 w-full mb-2"
-        placeholder="Title"
-        value={title}
-        onChange={e => setTitle(e.target.value)}
-      />
-      <input
-        className="border p-2 w-full mb-2"
-        placeholder="Client"
-        value={client}
-        onChange={e => setClient(e.target.value)}
-      />
-      <button className="bg-blue-500 text-white px-4 py-2">Save</button>
-    </form>
+    <div className="min-h-screen bg-gray-100 text-gray-900">
+      <nav className="bg-slate-800 text-white p-3 px-6 flex items-center gap-4">
+        <button onClick={() => navigate('/')} className="text-sm hover:underline">← Back to Dashboard</button>
+      </nav>
+
+      <main className="p-6 max-w-md mx-auto">
+        <h2 className="text-lg font-semibold mb-4">Create Case</h2>
+        <form onSubmit={handleSubmit}>
+          <input
+            required
+            placeholder="Case title"
+            className="w-full border border-gray-300 rounded mb-4 py-2 px-3 text-sm bg-white"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+          />
+          <input
+            required
+            placeholder="Client name"
+            className="w-full border border-gray-300 rounded mb-4 py-2 px-3 text-sm bg-white"
+            value={client}
+            onChange={e => setClient(e.target.value)}
+          />
+          <button type="submit" className="bg-blue-600 hover:bg-blue-700 text-white py-2 px-5 rounded text-sm">Save</button>
+        </form>
+      </main>
+    </div>
   );
 }

--- a/web/src/pages/Dashboard.jsx
+++ b/web/src/pages/Dashboard.jsx
@@ -1,24 +1,51 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import api from '../api.js';
 
 export default function Dashboard() {
   const [cases, setCases] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     api.get('/cases').then(res => setCases(res.data));
   }, []);
 
+  const logout = () => {
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+
   return (
-    <div className="p-4">
-      <Link to="/cases/new" className="underline">New Case</Link>
-      <ul>
-        {cases.map(c => (
-          <li key={c._id}>
-            <Link className="text-blue-500" to={`/cases/${c._id}`}>{c.title}</Link>
-          </li>
-        ))}
-      </ul>
+    <div className="min-h-screen bg-gray-100 text-gray-900">
+      <nav className="bg-slate-800 text-white p-3 px-6 flex justify-between">
+        <h1 className="font-semibold text-lg">⚖️ Lawyer Dashboard</h1>
+        <button onClick={logout} className="text-sm hover:underline">Logout</button>
+      </nav>
+
+      <main className="p-6 max-w-6xl mx-auto">
+        <header className="flex justify-between items-center mb-6">
+          <h2 className="text-xl font-semibold">Your Cases</h2>
+          <Link to="/cases/new" className="bg-green-600 hover:bg-green-700 text-white text-sm py-2 px-4 rounded">+ New Case</Link>
+        </header>
+
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {cases.map(c => (
+            <Link
+              key={c._id}
+              to={`/cases/${c._id}`}
+              className="border border-gray-200 rounded-lg p-4 bg-white hover:shadow"
+            >
+              <h3 className="font-semibold mb-1">{c.title}</h3>
+              <p className="text-sm text-gray-500 mb-1">Client: {c.client}</p>
+              <span
+                className={`inline-block px-2 py-1 rounded text-xs font-medium ${c.status === 'open' ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700'}`}
+              >
+                {c.status === 'open' ? 'Open' : 'Closed'}
+              </span>
+            </Link>
+          ))}
+        </section>
+      </main>
     </div>
   );
 }

--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -19,21 +19,35 @@ export default function Login() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="p-4 max-w-sm mx-auto">
-      <input
-        className="border p-2 w-full mb-2"
-        placeholder="Email"
-        value={email}
-        onChange={e => setEmail(e.target.value)}
-      />
-      <input
-        className="border p-2 w-full mb-2"
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={e => setPassword(e.target.value)}
-      />
-      <button className="bg-blue-500 text-white px-4 py-2">Login</button>
-    </form>
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white w-80 p-10 rounded-lg shadow"
+      >
+        <h1 className="text-center text-lg font-semibold mb-6">⚖️ Lawyer Login</h1>
+        <input
+          type="email"
+          required
+          placeholder="Email"
+          className="w-full border border-gray-300 rounded mb-4 py-2 px-3 text-sm"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          required
+          placeholder="Password"
+          className="w-full border border-gray-300 rounded mb-4 py-2 px-3 text-sm"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded text-sm"
+        >
+          Sign In
+        </button>
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- apply new styling to all React pages
- store evidence file size in backend
- seed demo user credentials
- document setup and demo account in README

## Testing
- `npm test --prefix api` *(fails: Missing script)*
- `npm test --prefix web` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684db4d978d883228c175b5679193cb5